### PR TITLE
Enables ES6 on server.js

### DIFF
--- a/Server/.babelrc
+++ b/Server/.babelrc
@@ -1,0 +1,4 @@
+{
+  "presets": ["es2015", "stage-2"],
+  "plugins": []
+}

--- a/Server/.gitignore
+++ b/Server/.gitignore
@@ -9,3 +9,4 @@ config.json
 ../.idea
 ../.expo
 /public/bundle.js
+/public/server.js

--- a/Server/package.json
+++ b/Server/package.json
@@ -5,8 +5,9 @@
   "main": "index.js",
   "repository": "",
   "scripts": {
-    "start": "node server.js",
-    "dev-1": "nodemon server.js"
+    "start": "nodemon server.js --exec babel-node",
+    "build": "babel server.js -d public",
+    "serve": "node public/server.js"
   },
   "author": "tjonnyc",
   "license": "proprietary",
@@ -25,6 +26,9 @@
     "stopwords": "^0.0.5"
   },
   "devDependencies": {
+    "babel-cli": "^6.24.1",
+    "babel-preset-es2015": "^6.24.1",
+    "babel-preset-stage-2": "^6.24.1",
     "eslint": "^3.18.0",
     "eslint-config-airbnb": "^14.1.0",
     "eslint-plugin-import": "^2.2.0",


### PR DESCRIPTION
To run the server use:
Development - `npm start`
Deployment build - `npm run build` (then use the `server.js` file in `public`)